### PR TITLE
bug - Update-ModuleManifest need all required dependecies installed

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -53,6 +53,11 @@ if ($DependencyInjection) {
     . $DependencyInjection 
 }
 
+## Install delendecies as Publish-Module 
+# will check if dependecies are installed locally due to a bug
+# in Test-ModuleManifest
+Install-Dependencies -ModuleManifestPath $MODULE_PSD1
+
 # Process Tag
 if($VersionTag){
 


### PR DESCRIPTION
This module has a dependency.
Different platforms funcitons require all dependenceies to be present on the computer not to error.

Update-ModuleManifest is one of them.

We already added Install-Dependenceis on deploy.helper.ps1 calling it before Invoke-DeployModule that calls Publish-Module that fails for the same reason when re RequiredModules are not installed localy.